### PR TITLE
fix if types int32 uint32 already defined

### DIFF
--- a/jWrite.c
+++ b/jWrite.c
@@ -16,8 +16,12 @@
 #include "jWrite.h"
 
 //#include <stdint.h>			// definintion of uint32_t, int32_t
+#ifndef _UINT32_T_DECLARED
 typedef unsigned int uint32_t;
+#endif
+#ifndef _INT32_T_DECLARED
 typedef int int32_t;
+#endif
 
 
 // the jWrite functions take the above jWriteControl structure pointer


### PR DESCRIPTION
Here you define types int32 and uint32. But in some architectures and toolchains they are already defined even if stdint.h is not included. It produces compillation error. We should verify if these types are defined.