### PR TITLE
Fix overwriting NUL termination

### DIFF
--- a/jWrite.c
+++ b/jWrite.c
@@ -281,7 +281,8 @@ enum jwNodeType jwPop(JWC_DECL0) {
 }
 
 void jwPutch(JWC_DECL char c) {
-  if ((unsigned int)(JWC(bufp) - JWC(buffer)) >= JWC(buflen)) {
+  unsigned int current_length = JWC(bufp) - JWC(buffer) + 1;
+  if (current_length >= JWC(buflen)) {
     JWC(error) = JWRITE_BUF_FULL;
   } else {
     *JWC(bufp)++ = c;


### PR DESCRIPTION
When to muth data is written to buffer last \0 was overwritten. This set the overflow flag so data was not written outside buffer but the NUL termination of the buffer was lost. jWrite states that it shall keep the buffer \0 terminated. Never write data to last char in buffer.